### PR TITLE
Remove old-style constructors

### DIFF
--- a/src/includes/PageControls.inc
+++ b/src/includes/PageControls.inc
@@ -53,4 +53,3 @@ function show_navbar( $active = 'home', $display = TRUE, $home_only = FALSE, $ex
 
     return $navblock;
 }
-?>

--- a/src/includes/PageHtml.class
+++ b/src/includes/PageHtml.class
@@ -29,4 +29,3 @@ class HtmlTemplate
         echo $this->html;
     }
 }
-?>

--- a/src/includes/common.inc
+++ b/src/includes/common.inc
@@ -98,4 +98,3 @@ function validate_projectID($param_name, $value, $allownull = FALSE)
 }
 
 // vim: sw=4 ts=4 expandtab
-

--- a/src/includes/connect.inc
+++ b/src/includes/connect.inc
@@ -6,7 +6,7 @@ class dbConnect
     var $error='';
     var $connection='';
 
-    function dbConnect()
+    function __construct()
     {
         $db_info = new db_udb_user();
         $db_link = mysqli_connect('p:'.
@@ -23,31 +23,15 @@ class dbConnect
         }
         else
         {
-//            echo "Host information: " . mysqli_get_host_info($db_link) . PHP_EOL;
             $this->connection = $db_link;
             return 1;
         }
-
-/*
-        // Not necessary to select db any more since it's done in the mysqli connection
-        if (!mysql_select_db($db_info->dbname,$this->db_lk))
-        {
-            $this->error=_("Unable to locate database.");
-            return 0;
-        }
-        else
-        {
-            return 1;
-        }
-*/
-
     }
 
     function close()
     {
         if (isset($this->db_lk))
         {
-//            mysql_close($this->db_lk);
             $this->close();
         }
     }

--- a/src/includes/parse_pg_rdf.inc
+++ b/src/includes/parse_pg_rdf.inc
@@ -102,4 +102,3 @@ function parse_pg_catalog_rdf($pg_id, $pg_catalog_dir)
 }
 
 // vim: sw=4 ts=4 expandtab
-

--- a/src/index.php
+++ b/src/index.php
@@ -48,5 +48,3 @@ $page->SetParameter ("BuildTime",       script_end_time($starttime));
 $page->CreatePage();
 
 // vim: sw=4 ts=4 expandtab
-?>
-

--- a/src/tools/biblio.php
+++ b/src/tools/biblio.php
@@ -249,5 +249,3 @@ function find_cover_image( $id )
 }
 
 // vim: sw=4 ts=4 expandtab
-?>
-

--- a/src/tools/browse.php
+++ b/src/tools/browse.php
@@ -246,5 +246,3 @@ function displaybrowse($browse, $limit, $pagenum)
 }
 
 // vim: sw=4 ts=4 expandtab
-?>
-

--- a/src/tools/display.php
+++ b/src/tools/display.php
@@ -271,5 +271,3 @@ function scanDirectoryImages($directory, array $exts = array('jpg', 'png'))
 }
 
 // vim: sw=4 ts=4 expandtab
-?>
-

--- a/src/tools/search.php
+++ b/src/tools/search.php
@@ -163,5 +163,3 @@ function highlight_search_term($string, $searchterm)
 }
 
 // vim: sw=4 ts=4 expandtab
-?>
-


### PR DESCRIPTION
Remove old-style constructors to fix deprecation warning.

Also do a small bit of cleanup.